### PR TITLE
feat(blog): próxima leitura

### DIFF
--- a/.trae/specs/add-next-reading/checklist.md
+++ b/.trae/specs/add-next-reading/checklist.md
@@ -1,0 +1,7 @@
+- [x] Ao final de qualquer artigo do blog, existe um bloco de recomendação de próxima leitura (quando aplicável).
+- [x] O bloco exibe uma lista com até 3 itens, ordenados do mais recente para o menos recente.
+- [x] Cada item exibe somente título e resumo do conteúdo recomendado.
+- [x] Cada item é clicável e direciona para a página do conteúdo recomendado.
+- [x] O artigo atual nunca aparece como item recomendado.
+- [x] Se não existir nenhum outro conteúdo disponível além do atual, o bloco de recomendação não é exibido.
+- [x] Se existirem apenas 1 ou 2 conteúdos disponíveis (excluindo o atual), o bloco é exibido com somente 1 ou 2 itens, respectivamente.

--- a/.trae/specs/add-next-reading/spec.md
+++ b/.trae/specs/add-next-reading/spec.md
@@ -1,0 +1,47 @@
+# Bloco de Próxima Leitura no Artigo Spec
+
+## Why
+Ao concluir a leitura de um artigo, o leitor chega ao fim da página sem uma orientação clara do que consumir a seguir, aumentando a chance de saída do site.
+
+## What Changes
+- Exibir um bloco de “Próxima leitura” ao final de qualquer artigo do blog, com até 3 recomendações.
+- Recomendações serão os conteúdos mais recentes do blog, ordenados do mais recente para o menos recente.
+- O artigo atual (o que o leitor acabou de ler) nunca deve aparecer na lista.
+- Cada item exibirá apenas: título e resumo; o item será clicável e levará para o respectivo artigo.
+- O bloco não deve ser exibido quando não existir nenhum outro conteúdo disponível além do atual.
+- Se houver menos de 3 conteúdos disponíveis (excluindo o atual), exibir somente os disponíveis, sem placeholders.
+
+## Impact
+- Affected specs: navegação/continuidade de leitura no domínio de blog
+- Affected code:
+  - `src/pages/blog/[...slug].astro` (inclusão do bloco no template e preparação dos dados)
+  - `src/features/blog/components/*` (novo componente de UI para “Próxima leitura”)
+
+## ADDED Requirements
+### Requirement: Recomendações de próxima leitura
+O sistema SHALL exibir, ao final de qualquer artigo do blog, um bloco de “Próxima leitura” com até 3 itens recomendados, ordenados por data do mais recente para o menos recente, excluindo o artigo atual.
+
+#### Scenario: Exibição com 3 itens
+- **WHEN** o leitor chega ao final de um artigo e existem pelo menos 3 outros conteúdos publicados
+- **THEN** o bloco é exibido com exatamente 3 itens, ordenados do mais recente para o menos recente
+- **AND** cada item exibe apenas título e resumo
+- **AND** cada item é clicável e direciona para `/blog/<slug>`
+- **AND** o artigo atual não aparece na lista
+
+#### Scenario: Exibição com 1 ou 2 itens
+- **WHEN** o leitor chega ao final de um artigo e existem apenas 1 ou 2 outros conteúdos (excluindo o atual)
+- **THEN** o bloco é exibido com 1 ou 2 itens, respectivamente
+- **AND** não existem itens vazios/placeholder para completar 3
+
+#### Scenario: Não exibir sem alternativas
+- **WHEN** o leitor chega ao final de um artigo e não existe nenhum outro conteúdo disponível além do atual
+- **THEN** o bloco de “Próxima leitura” não é exibido
+
+## MODIFIED Requirements
+### Requirement: Renderização de página de artigo do blog
+O sistema SHALL manter a renderização do artigo em `/blog/[...slug]` e adicionar, no final do conteúdo do artigo, o bloco de “Próxima leitura” conforme os requisitos adicionados.
+
+## REMOVED Requirements
+### Requirement: Personalização/curadoria de recomendações
+**Reason**: Fora de escopo.
+**Migration**: N/A.

--- a/.trae/specs/add-next-reading/tasks.md
+++ b/.trae/specs/add-next-reading/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+- [x] Task 1: Preparar lista de recomendações no artigo do blog
+  - [x] Buscar todos os posts via `getCollection("posts")` na rota do artigo.
+  - [x] Ordenar por `data.date` (descendente) e excluir o post atual pelo `id/slug`.
+  - [x] Selecionar até 3 itens para exibição, preservando a ordenação.
+  - [x] Garantir que a lista possa ser vazia (para controlar não renderização do bloco).
+
+- [x] Task 2: Criar componente de UI “Próxima leitura”
+  - [x] Criar componente Astro no domínio de blog para renderizar: título do bloco + lista de itens.
+  - [x] Definir `type Props` com a lista de itens recomendados (slug, title, summary).
+  - [x] Renderizar somente `title` e `summary` e link para `/blog/<slug>`.
+  - [x] Não renderizar o componente quando a lista estiver vazia.
+
+- [x] Task 3: Integrar o componente na página do artigo
+  - [x] Inserir o componente ao final do artigo em `src/pages/blog/[...slug].astro` (após o conteúdo do post).
+  - [x] Confirmar que o artigo atual nunca é exibido como recomendado.
+
+- [x] Task 4: Validação local e regressão
+  - [x] Verificar manualmente os casos: 0, 1, 2 e 3+ posts disponíveis (excluindo o atual).
+  - [x] Rodar `pnpm lint` e corrigir eventuais warnings/erros.
+  - [x] Rodar `pnpm build` para validar geração estática do blog.
+
+# Task Dependencies
+- Task 2 depende de Task 1 (contrato de dados para a lista).
+- Task 3 depende de Task 2.
+- Task 4 depende de Tasks 1–3.

--- a/src/features/blog/components/next-reading.astro
+++ b/src/features/blog/components/next-reading.astro
@@ -1,0 +1,43 @@
+---
+type RecommendationItem = {
+  slug: string;
+  title: string;
+  summary: string;
+};
+
+type Props = {
+  items: RecommendationItem[];
+};
+
+const { items } = Astro.props as Props;
+---
+
+{
+  items?.length > 0 && (
+    <section class="border-tertiary bg-tertiary/25 mt-10 flex flex-col gap-6 rounded-xl border p-6 lg:mt-14">
+      <header class="flex flex-col gap-2">
+        <h2 class="text-primary text-xl font-semibold lg:text-2xl">
+          Próxima leitura
+        </h2>
+        <p class="text-secondary text-sm leading-relaxed lg:text-base">
+          Se quiser continuar, aqui vão alguns posts pra ler na sequência.
+        </p>
+      </header>
+      <div class="flex flex-col gap-4">
+        {items.map(item => (
+          <a
+            href={`/blog/${item.slug}`}
+            class="border-tertiary bg-background/30 hover:bg-background/45 group flex flex-col gap-2 rounded-md border p-4 transition-colors"
+          >
+            <h3 class="text-primary text-base leading-tight font-semibold lg:text-lg">
+              {item.title}
+            </h3>
+            <p class="text-secondary text-sm leading-relaxed lg:text-base">
+              {item.summary}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,6 +12,7 @@ import BackToPrev from "@src/features/blog/components/back-to-prev.astro";
 import ShareBar from "@src/features/blog/components/share-bar.astro";
 import GreatImage from "@src/components/great-image/index.astro";
 import SummaryAIButton from "@src/features/blog/components/summary-ai-button.astro";
+import NextReading from "@src/features/blog/components/next-reading.astro";
 
 import { readingTime } from "@src/features/blog/utility";
 
@@ -27,6 +28,19 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<"posts">;
 
 const post = Astro.props;
+
+const posts = await getCollection("posts");
+const recommendedPosts = posts
+  .filter(item => item.id !== post.id)
+  .sort((a, b) => {
+    return new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf();
+  })
+  .slice(0, 3)
+  .map(item => ({
+    slug: item.id,
+    title: item.data.title,
+    summary: item.data.summary,
+  }));
 
 const date = new Date(post.data.date);
 const readingTimeInMinutes = readingTime(post.body || "");
@@ -121,16 +135,20 @@ const defaultCoverSize = {
         >
           <!-- IA Resum injected -->
           <div id="summary-skeleton-content" class="flex flex-col gap-4">
-            <div class="animate-pulse bg-tertiary w-full max-w-[400px] rounded-md p-4"></div>
-            <div class="animate-pulse bg-tertiary w-full rounded-md p-4"></div>
-            <div class="animate-pulse bg-tertiary w-full rounded-md p-4"></div>
-            <div class="animate-pulse bg-tertiary w-full rounded-md p-4"></div>
+            <div
+              class="bg-tertiary w-full max-w-[400px] animate-pulse rounded-md p-4"
+            >
+            </div>
+            <div class="bg-tertiary w-full animate-pulse rounded-md p-4"></div>
+            <div class="bg-tertiary w-full animate-pulse rounded-md p-4"></div>
+            <div class="bg-tertiary w-full animate-pulse rounded-md p-4"></div>
           </div>
         </div>
       </div>
     </summary-content-ai>
     <Content />
   </div>
+  <NextReading items={recommendedPosts} />
   <footer class="text-secondary mt-8 rounded-md leading-relaxed text-balance">
     <h5 class="mb-4 text-xl font-semibold text-white lg:text-3xl">
       Concluída!


### PR DESCRIPTION
Adiciona bloco de Próxima leitura ao final do artigo com até 3 posts mais recentes (exclui o atual), exibindo apenas título e resumo.